### PR TITLE
feat: go into a runtime error state when usbl is below a safe pressure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ templates/*
 build/*
 
 *autobuild-stamp
-
+.vscode/c_cpp*

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -11,6 +11,7 @@ using base::samples::RigidBodyState;
 Task::Task(std::string const& name)
     : TaskBase(name)
 {
+    _safe_operational_pressure.set(Pressure::fromBar(base::Time::now(), 1.01));
 }
 
 Task::~Task()
@@ -99,6 +100,7 @@ bool Task::configureHook()
     mMsgType = _msg_type.get();
     m_orientation_output_flag = _orientation_output_flag.get();
     m_ping_refresh_period = _ping_refresh_period.get();
+    m_safe_operational_pressure = _safe_operational_pressure.get();
 
     mDriver = move(driver);
     guard.commit();
@@ -131,20 +133,26 @@ bool Task::startHook()
 
 void Task::updateHook()
 {
+
     Status status = mDriver->getStatusProtocol(
-        protocol::STATUS_ENVIRONMENT | protocol::STATUS_ATTITUDE
-    );
+        protocol::STATUS_ENVIRONMENT | protocol::STATUS_ATTITUDE);
     RigidBodyState rbs_reference;
     // Write the local usbl depth
-    rbs_reference.position = Eigen::Vector3d(
-        NAN, NAN, -static_cast<float>(status.environment.pressure) / 100.
-    );
+    rbs_reference.position = Eigen::Vector3d(NAN,
+        NAN,
+        -static_cast<float>(status.environment.pressure) / 100.);
     // Write the local usbl orientation
     if (m_orientation_output_flag) {
         rbs_reference.orientation = convertToOrientationQuaterniond(status);
     }
     rbs_reference.time = base::Time::now();
     _local2nwu_orientation_with_z.write(rbs_reference);
+
+    checkWorkingPressure(status.environment.pressure);
+    // Early return to avoid pinging when its not safe
+    if (state() == UNSAFE_WORKING_PRESSURE) {
+        return;
+    }
 
     if (base::Time::now() - m_previous_ping_refresh_time > m_ping_refresh_period) {
         m_previous_ping_refresh_time = base::Time::now();
@@ -170,6 +178,14 @@ void Task::processIO()
 void Task::errorHook()
 {
     TaskBase::errorHook();
+
+    if (state() == UNSAFE_WORKING_PRESSURE) {
+        Status status = mDriver->getStatusProtocol(protocol::STATUS_ENVIRONMENT);
+        if (base::isUnknown(m_safe_operational_pressure.toBar()) ||
+            status.environment.pressure > m_safe_operational_pressure.toBar()) {
+            recover();
+        }
+    }
 }
 
 void Task::stopHook()
@@ -181,4 +197,12 @@ void Task::cleanupHook()
 {
     TaskBase::cleanupHook();
     mDriver.reset();
+}
+
+void Task::checkWorkingPressure(int32_t pressure)
+{
+    if (pressure < m_safe_operational_pressure.toBar() &&
+        state() != UNSAFE_WORKING_PRESSURE) {
+        error(UNSAFE_WORKING_PRESSURE);
+    }
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -53,6 +53,8 @@ argument.
          */
         bool m_orientation_output_flag;
 
+        base::Pressure m_safe_operational_pressure;
+
         void processIO();
 
     public:
@@ -143,6 +145,8 @@ argument.
             bool xcvr_fix_msgs,
             bool xcvr_diag_msgs,
             float xcvr_range_tmo);
+
+        void checkWorkingPressure(int32_t pressure);
     };
 }
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -153,8 +153,34 @@ describe OroGen.usbl_seatrac.Task do
         end
     end
 
+    describe "behavior when in unsafe working pressure" do
+        before do
+            ping_refresh_period = Time.at(0.0)
+            usbl_task_setup(ping_refresh_period, false, 500_000)
+            usbl_configure_and_start(raw_io, task)
+        end
+
+        it "does not ping if the pressure is below the safe threshold" do
+            packet1 = raw_packet_from_s("$1001B200000000000000010001000100000001000000" \
+                "0100B429\r\n$")
+            packet2 = raw_packet_from_s("$4000028015\r\n")
+            packet3 = raw_packet_from_s("$42020F07020101010101010101010101010101010101" \
+                "010101010101010101010101010101010101010101010101010101B0\r\n")
+            response =
+                expect_execution \
+                    { syskit_write @raw_io.out_port, packet1, packet2, packet3 }
+                .to do
+                    emit(task.unsafe_working_pressure_event)
+                    have_no_new_sample task.ping_status_port
+                end
+        end
+    end
+
     # rubocop: disable Metrics/AbcSize
-    def usbl_task_setup(ping_refresh_period, orientation_output_flag)
+    def usbl_task_setup(
+        ping_refresh_period, orientation_output_flag,
+        safe_operational_pressure = Float::NAN
+    )
         @task = syskit_deploy(OroGen.usbl_seatrac.Task.deployed_as("usbl_test"))
         @task.properties.destination_id = 0x02
         @task.properties.msg_type = 0x06
@@ -174,6 +200,7 @@ describe OroGen.usbl_seatrac.Task do
         @task.properties.status_mode = 0x02
         @task.properties.ping_refresh_period = ping_refresh_period
         @task.properties.orientation_output_flag = orientation_output_flag
+        @task.properties.safe_operational_pressure = { pascal: safe_operational_pressure }
         @raw_io = setup_iodrivers_base_with_ports(@task, configure_and_start: false)
     end
 

--- a/usbl_seatrac.orogen
+++ b/usbl_seatrac.orogen
@@ -61,12 +61,17 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # How often periodic status output messages are generated
     property "status_mode", "usbl_seatrac/protocol/StatusMode",
              "STATUS_MODE_2HZ5"
+    # Goes into exception if the working pressure is below this value. Set it to NAN to
+    # disable it
+    property "safe_operational_pressure", "/base/Pressure"
 
     # Position of the remote transponder in relation to the master's device body pose
     output_port("remote2local_position", "base/samples/RigidBodyState")
     # USBL Beacon X150  - z = local_depth , orientation = local_attitude
     output_port("local2nwu_orientation_with_z", "base/samples/RigidBodyState")
     output_port("ping_status", "usbl_seatrac/PingStatus")
+
+    error_states "UNSAFE_WORKING_PRESSURE"
 
     periodic 0.1
 end


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
